### PR TITLE
Add ZK benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,43 @@ Both on [Bitcoin](https://github.com/sCrypt-Inc/snarkjs) and [Ethereum](https://
 | verifying time      | ~O(1)                      | O(poly-log(N))                | O(N)            |
 | proof size | ~O(1)                      | O(poly-log(N))                | O(log(N))       |
 | Trusted setup required?               | YES :unamused:             | NO :smile:                    | NO :smile:      |
+
+
+- [🏋️‍♀️ ZK Bench](https://zkbench.dev) - open source, continuous benchmarks for popular zk implementations
+
+| | [**Polylang**](https://polylang.dev) | [**Miden**](https://wiki.polygon.technology/docs/miden/) | [**Risc Zero**](https://risczero.com/) | [**Noir (Barretenberg)**](https://noir-lang.org/) | [**Leo**](https://leo-lang.org/) |
+|---|---|---|---|---|---|
+| **Frontend (Language)** | Typescript-like | MASM (Assembly) | Rust, C, C++ | Rust-like | Leo (DSL) |
+| **ZK** | STARK | STARK / zkVM | STARK / zkVM | SNARK | SNARK |
+| **Unbounded Programs** | ✅ | ✅ | ✅ | ❌ | ❌ |
+| **Audit** | ❌ Planned 2024 | ❌ Planned 2024 | ❌ Planned 2024 | ❌ Planned 2024 | ❌ Planned 2023 |
+| **External Libraries** | ❌ | ⚠️ | ✅ | ⚠️ | ⚠️ |
+| **EVM Verifier** | ⚠️ | ⚠️ | ✅ | ✅ | ❌ |
+| **GPU** | ✅ Metal | ✅ Metal | ✅ Metal, CUDA | ❌ | ❌ |
+| **Assert** | 0.05s | 0.03s | 6.18s | 0.01s | 3.11s |
+| **Optimised Hashes** | RPO+2 more | RPO+2 more | SHA-256 | Pedersen+2 more | Pedersen+3 more |
+| **SHA-256 Hash** |  |  |  |  |  |
+| **1k bytes** | 21.55s | 20.33s | 6.20s | 3.63s | 2.81s |
+| **10k bytes** | 235.71s | 177.79s | 6.27s | 33.89s | 10.81s |
+| **Pedersen Hash** |  |  |  |  |  |
+| **1k bytes** | ❌ | ❌ | ❌ | 0.54s | 1.99s |
+| **10k bytes** | ❌ | ❌ | ❌ | 1.87s | 2.28s |
+| **RPO Hash** |  |  |  |  |  |
+| **1k bytes** | 0.17s | 0.03s | ❌ | ❌ | ❌ |
+| **10k bytes** | 1.85s | 0.30s | ❌ | ❌ | ❌ |
+| **Fibonacci** |  |  |  |  |  |
+| **1** | 0.03s | 0.03s | 6.20s | 0.01s | 1.89s |
+| **10** | 0.05s | 0.03s | 6.21s | 0.01s | 1.89s |
+| **100** | 0.16s | 0.03s | 6.20s | 0.01s | 1.88s |
+| **1,000** | 2.56s | 0.08s | 6.17s | 0.01s | 1.89s |
+| **10,000** | 21.17s | 0.59s | 12.57s | 0.01s | 1.91s |
+| **100,000** | 221.24s | 9.55s | 105.13s | 0.01s | 🚧 |
+| **Merkle Tree** |  |  |  |  |  |
+| **Membership Proof** | 🚧 | 0.06s | 12.56s | 3.52s | 🚧 |
+| **Merge** |  |  |  |  |  |
+| **1 + 1** | 🚧 | 0.06s | 12.65s | 🚧 | 🚧 |
+
+
 - [Proving system comparison](https://youtu.be/LBTrX0Ukdvs?t=309) ![compare snarks](./images/compare_snarks3.png)
 - [zk-SNARKs vs. Zk-STARKs vs. BulletProofs](https://ethereum.stackexchange.com/questions/59145/zk-snarks-vs-zk-starks-vs-bulletproofs-updated) ![compare](./images/comparisons.png)
 - [Comparing General Purpose zk-SNARKs](https://medium.com/coinmonks/comparing-general-purpose-zk-snarks-51ce124c60bd) ![compare snarks](./images/compare_snarks2.png)


### PR DESCRIPTION
My team had difficulty comparing different zk frameworks so we made a open source, continuous benchmarking site. We had leads from Polygon Miden, Aztec, RISC Zero and Aleo review as well.

We put a bunch of work into detangling the caveats and tradeoffs of the different frameworks — hope it's useful for choosing your next framework!

Check it out here: https://zkbench.dev/