### PR TITLE
fix misconception that all snarks require a trusted setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Both on [Bitcoin](https://github.com/sCrypt-Inc/snarkjs) and [Ethereum](https://
 | proving time       | O(N * log(N))              | O(N * poly-log(N))            | O(N * log(N))   |
 | verifying time      | ~O(1)                      | O(poly-log(N))                | O(N)            |
 | proof size | ~O(1)                      | O(poly-log(N))                | O(log(N))       |
-| Trusted setup required?               | YES :unamused:             | NO :smile:                    | NO :smile:      |
+| Trusted setup required?               | SOMETIMES :neutral_face:             | NO :smile:                    | NO :smile:      |
 
 
 - [🏋️‍♀️ ZK Bench](https://zkbench.dev) - open source, continuous benchmarks for popular zk implementations


### PR DESCRIPTION
The "Halo" SNARK system described in the "[Recursive Proof Composition without a trusted Setup](https://eprint.iacr.org/2019/1021.pdf)" by the Electric Coin Company (i.e. the Z Cash team) introduced a SNARK which as the title describes, does not in fact require a trusted setup. Halo 2, Z Cash's subsequent proof system and Mina's [Kimchi and Pickles SNARK systems](https://o1-labs.github.io/proof-systems/specs/urs.html) use the same technique to avoid the need for a trusted setup as well. 